### PR TITLE
update output file logic

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -157,7 +157,7 @@ export default class Changelog {
 
         progressBar.tick();
       },
-      { concurrency: 5 }
+      { concurrency: 1 }
     );
     progressBar.terminate();
   }
@@ -220,7 +220,7 @@ export default class Changelog {
 
           progressBar.tick();
         },
-        { concurrency: 5 }
+        { concurrency: 1 }
       );
     } finally {
       progressBar.terminate();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,8 @@ import Changelog from "./changelog";
 import { load as loadConfig } from "./configuration";
 import ConfigurationError from "./configuration-error";
 
+import fs = require("fs");
+
 const NEXT_VERSION_DEFAULT = "Unreleased";
 
 export async function run() {
@@ -48,6 +50,11 @@ export async function run() {
         desc: "`<USER|ORG>/<PROJECT>` of the GitHub project",
         defaultDescription: "inferred from the `package.json` file",
       },
+      output: {
+        type: "string",
+        desc: "output file",
+        default: "",
+      },
     })
     .example(
       "lerna-changelog",
@@ -88,6 +95,15 @@ export async function run() {
     });
 
     console.log(highlighted);
+
+    if (argv["output"] !== "") {
+      fs.writeFile(argv["output"], result, err => {
+        if (err) {
+          console.error(err);
+          process.exitCode = 1;
+        }
+      });
+    }
   } catch (e) {
     if (e instanceof ConfigurationError) {
       console.log(chalk.red(e.message));


### PR DESCRIPTION
1. concurrency가 5로 설정되어 있음. -> GitHub api call을 5개씩 한번에 보냄. -> GitHub api 가 handling을 못 하는지 stuck됨.
  - concurrency 1로 설정하는 것이 훨씬 빠르게 response가 오고 handling됨.
2. changelog를 output file로 출력하는 option 추가함